### PR TITLE
set symmentrical=False in User model, add/remove codes for followers …

### DIFF
--- a/nomadgram/users/models.py
+++ b/nomadgram/users/models.py
@@ -24,8 +24,8 @@ class User(AbstractUser):
     bio = models.TextField(null=True)
     phone = models.CharField(max_length=140, null=True)
     gender = models.CharField(max_length=80, choices=GENDER_CHOICES, null=True)
-    followers = models.ManyToManyField("self", blank=True)
-    following = models.ManyToManyField("self", blank=True)
+    followers = models.ManyToManyField("self", blank=True, symmetrical=False, related_name='nomadgram_followers')
+    following = models.ManyToManyField("self", blank=True, symmetrical=False, related_name='nomadgram_following')
     push_token = models.TextField(default='')
 
     def __str__(self):

--- a/nomadgram/users/views.py
+++ b/nomadgram/users/views.py
@@ -31,6 +31,7 @@ class FollowUser(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         user.following.add(user_to_follow)
+        user_to_follow.followers.add(user)
 
         user.save()
 
@@ -51,6 +52,7 @@ class UnFollowUser(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         user.following.remove(user_to_follow)
+        user_to_follow.followers.remove(user)
 
         user.save()
 


### PR DESCRIPTION
(I think this issue is already acknowledged by you. Also, there are feedbacks in comments thread in lecture page about it. I found this issue during a discussion in the slack channel, and I'd like to pull request with some codes.)

Currently, if API is called to add following to User, requesting user and following user are all added to their following symmetrically.

So, I added `symmetrical=False` and `related_name=` for reverse reference in the User model. and some codes to add requesting user as a follower to the following user asymmetrically.

Lastly, I hope to know how to add symmetrically one user as following and another user as follower in User model level with one side action, if it is possible.